### PR TITLE
Add completion block dismiss selectors. Also added ability to update …

### DIFF
--- a/JDStatusBarNotification/JDStatusBarNotification.h
+++ b/JDStatusBarNotification/JDStatusBarNotification.h
@@ -175,6 +175,12 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  */
 + (BOOL)isVisible;
 
+/**
+ * Gives api access to the percentage of how much the
+ * progress view bar has filled up the top bar
+ */
++ (CGFloat)exactPercentageOfProgressView;
+
 @end
 
 

--- a/JDStatusBarNotification/JDStatusBarNotification.h
+++ b/JDStatusBarNotification/JDStatusBarNotification.h
@@ -154,8 +154,18 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  *  Show the progress below the label.
  *
  *  @param progress Relative progress from 0.0 to 1.0
+ *  Animation duration defaults to 0.05 with this method
  */
 + (void)showProgress:(CGFloat)progress;
+
+/**
+ *  Show the progress below the label.
+ *
+ *  @param progress Relative progress from 0.0 to 1.0
+ *  @param duration The amount of time the progress bar
+ *  will take animating between cycles
+ */
++ (void)showProgress:(CGFloat)progress withAnimationDuration:(NSTimeInterval)duration;
 
 /**
  *  Shows an activity indicator in front of the notification text

--- a/JDStatusBarNotification/JDStatusBarNotification.h
+++ b/JDStatusBarNotification/JDStatusBarNotification.h
@@ -91,6 +91,7 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  *  Calls dismissAnimated: with animated set to YES
  */
 + (void)dismiss;
++ (void)dismissWithCompletion:(void (^ __nullable)(BOOL finished))completion;
 
 /**
  *  Dismisses any currently displayed notification immediately
@@ -99,6 +100,7 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  *  for presentation will also be used for the dismissal.
  */
 + (void)dismissAnimated:(BOOL)animated;
++ (void)dismissAnimated:(BOOL)animated completion:(void (^ __nullable)(BOOL finished))completion;
 
 /**
  *  Same as dismissAnimated:, but you can specify a delay,
@@ -107,6 +109,8 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  *  @param delay The delay, how long the notification should stay visible
  */
 + (void)dismissAfter:(NSTimeInterval)delay;
++ (void)dismissAfter:(NSTimeInterval)delay completion:(void (^ __nullable)(BOOL finished))completion;
+
 
 #pragma mark Styles
 
@@ -138,6 +142,13 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
                    prepare:(JDPrepareStyleBlock)prepareBlock;
 
 #pragma mark progress & activity
+
+/**
+ *  Update the label.
+ *
+ *  @param status New message
+ */
++ (void)updateStatus:(NSString*)status;
 
 /**
  *  Show the progress below the label.

--- a/JDStatusBarNotification/JDStatusBarNotification.h
+++ b/JDStatusBarNotification/JDStatusBarNotification.h
@@ -91,7 +91,7 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  *  Calls dismissAnimated: with animated set to YES
  */
 + (void)dismiss;
-+ (void)dismissWithCompletion:(void (^ __nullable)(BOOL finished))completion;
++ (void)dismissWithCompletion:(void (^)(BOOL finished))completion;
 
 /**
  *  Dismisses any currently displayed notification immediately
@@ -100,7 +100,7 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  *  for presentation will also be used for the dismissal.
  */
 + (void)dismissAnimated:(BOOL)animated;
-+ (void)dismissAnimated:(BOOL)animated completion:(void (^ __nullable)(BOOL finished))completion;
++ (void)dismissAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
 
 /**
  *  Same as dismissAnimated:, but you can specify a delay,
@@ -109,7 +109,7 @@ typedef JDStatusBarStyle*(^JDPrepareStyleBlock)(JDStatusBarStyle *style);
  *  @param delay The delay, how long the notification should stay visible
  */
 + (void)dismissAfter:(NSTimeInterval)delay;
-+ (void)dismissAfter:(NSTimeInterval)delay completion:(void (^ __nullable)(BOOL finished))completion;
++ (void)dismissAfter:(NSTimeInterval)delay completion:(void (^)(BOOL finished))completion;
 
 
 #pragma mark Styles

--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -41,6 +41,18 @@
 @synthesize progressView = _progressView;
 @synthesize topBar = _topBar;
 
+#pragma mark - Getter
+
+- (CGFloat)progress
+{
+    if isnan(_progress)
+    {
+        return 0;
+    }
+    
+    return _progress;
+}
+
 #pragma mark Class methods
 
 + (JDStatusBarNotification*)sharedInstance {

--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -594,7 +594,7 @@ static BOOL JDUIViewControllerBasedStatusBarAppearanceEnabled() {
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    if(JDUIViewControllerBasedStatusBarAppearanceEnabled()) {
+    if(JDUIViewControllerBasedStatusBarAppearanceEnabled() && [self mainController] != nil ) {
         return [[self mainController] preferredStatusBarStyle];
     }
     

--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -557,7 +557,7 @@
         topController = topController.presentedViewController;
     }
     
-    return topController;
+    return topController == self ? nil : topController;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
@@ -569,23 +569,23 @@
 }
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-    - (NSUInteger)supportedInterfaceOrientations {
+- (NSUInteger)supportedInterfaceOrientations {
 #else
-    - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
 #endif
     return [[self mainController] supportedInterfaceOrientations];
 }
-
+    
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
     return [[self mainController] preferredInterfaceOrientationForPresentation];
 }
-
+    
 // statusbar
 
 static BOOL JDUIViewControllerBasedStatusBarAppearanceEnabled() {
     static BOOL enabled = NO;
     static dispatch_once_t onceToken;
-
+    
     dispatch_once(&onceToken, ^{
         enabled = [[[[NSBundle mainBundle] infoDictionary] objectForKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue];
     });
@@ -594,7 +594,7 @@ static BOOL JDUIViewControllerBasedStatusBarAppearanceEnabled() {
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    if(JDUIViewControllerBasedStatusBarAppearanceEnabled() && [self mainController] != nil ) {
+    if(JDUIViewControllerBasedStatusBarAppearanceEnabled() && [self mainController] != nil && [[self mainController] respondsToSelector:@selector(preferredStatusBarStyle)]) {
         return [[self mainController] preferredStatusBarStyle];
     }
     
@@ -606,7 +606,7 @@ static BOOL JDUIViewControllerBasedStatusBarAppearanceEnabled() {
 }
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation {
-    if(JDUIViewControllerBasedStatusBarAppearanceEnabled()) {
+    if(JDUIViewControllerBasedStatusBarAppearanceEnabled() && [self mainController] != nil && [[self mainController] respondsToSelector:@selector(preferredStatusBarUpdateAnimation)]) {
         return [[self mainController] preferredStatusBarUpdateAnimation];
     }
     return [super preferredStatusBarUpdateAnimation];

--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -92,17 +92,17 @@
 
 + (void)dismissWithCompletion:(void (^ __nullable)(BOOL finished))completion;
 {
-	[self dismissAnimated:YES completion:completion];
+    [self dismissAnimated:YES completion:completion];
 }
 
 + (void)dismissAnimated:(BOOL)animated;
 {
-	[[JDStatusBarNotification sharedInstance] dismissAnimated:animated completion:nil];
+    [[JDStatusBarNotification sharedInstance] dismissAnimated:animated completion:nil];
 }
 
 + (void)dismissAnimated:(BOOL)animated completion:(void (^ __nullable)(BOOL finished))completion
 {
-	[[JDStatusBarNotification sharedInstance] dismissAnimated:animated completion:completion];
+    [[JDStatusBarNotification sharedInstance] dismissAnimated:animated completion:completion];
 }
 
 + (void)dismissAfter:(NSTimeInterval)delay
@@ -112,7 +112,7 @@
 
 + (void)dismissAfter:(NSTimeInterval)delay completion:(void (^ __nullable)(BOOL finished))completion
 {
-	[[JDStatusBarNotification sharedInstance] setDismissTimerWithInterval:delay completion:completion];
+    [[JDStatusBarNotification sharedInstance] setDismissTimerWithInterval:delay completion:completion];
 }
 
 + (void)setDefaultStyle:(JDPrepareStyleBlock)prepareBlock;
@@ -132,7 +132,7 @@
 
 + (void)updateStatus:(NSString*)status
 {
-	[[JDStatusBarNotification sharedInstance] updateStatus:status];
+    [[JDStatusBarNotification sharedInstance] updateStatus:status];
 }
 
 + (void)showProgress:(CGFloat)progress;
@@ -300,12 +300,12 @@
             self.topBar.transform = CGAffineTransformMakeTranslation(0, -self.topBar.frame.size.height);
         }
     } completion:^(BOOL finished) {
-		
-		if (completion)
-		{
-			completion(finished);
-		}
-		
+        
+        if (completion)
+        {
+            completion(finished);
+        }
+        
         [self.overlayWindow removeFromSuperview];
         [self.overlayWindow setHidden:YES];
         _overlayWindow.rootViewController = nil;
@@ -363,8 +363,8 @@
 
 - (void)updateStatus:(NSString*)status
 {
-	UILabel *textLabel = self.topBar.textLabel;
-	textLabel.text = status;
+    UILabel *textLabel = self.topBar.textLabel;
+    textLabel.text = status;
 }
 
 - (void)setProgress:(CGFloat)progress;
@@ -418,9 +418,14 @@
     
     // update progressView frame
     BOOL animated = !CGRectEqualToRect(self.progressView.frame, CGRectZero);
-    [UIView animateWithDuration:animated ? 0.05 : 0.0 delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
+    [UIView animateWithDuration:animated ? 1.0 : 0.0 delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
         self.progressView.frame = frame;
     } completion:nil];
+}
+
++ (CGFloat)exactPercentageOfProgressView
+{
+    return [JDStatusBarNotification sharedInstance].progressView.frame.size.width / [JDStatusBarNotification sharedInstance].topBar.frame.size.width;
 }
 
 - (void)showActivityIndicator:(BOOL)show


### PR DESCRIPTION
There are 2 changes represented in this pull request...
#1) Additional dismiss selectors are introduced that allow for a completion block to be passed as a parameter. The completion block is called when the notification has been dismissed.
#2) The updateStatus selector is introduced, allowing for the current displayed status message to be changed by the client.
