### PR TITLE
Fix enum documentation (formerly offset by 1 case)

### DIFF
--- a/JDStatusBarNotification/JDStatusBarStyle.h
+++ b/JDStatusBarNotification/JDStatusBarStyle.h
@@ -9,26 +9,41 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-extern NSString *const JDStatusBarStyleError;   /// This style has a red background with a white Helvetica label.
-extern NSString *const JDStatusBarStyleWarning; /// This style has a yellow background with a gray Helvetica label.
-extern NSString *const JDStatusBarStyleSuccess; /// This style has a green background with a white Helvetica label.
-extern NSString *const JDStatusBarStyleMatrix;  /// This style has a black background with a green bold Courier label.
-extern NSString *const JDStatusBarStyleDefault; /// This style has a white background with a gray Helvetica label.
-extern NSString *const JDStatusBarStyleDark;    /// This style has a nearly black background with a nearly white Helvetica label.
+/// This style has a red background with a white Helvetica label.
+extern NSString *const JDStatusBarStyleError;
+/// This style has a yellow background with a gray Helvetica label.
+extern NSString *const JDStatusBarStyleWarning;
+/// This style has a green background with a white Helvetica label.
+extern NSString *const JDStatusBarStyleSuccess;
+/// This style has a black background with a green bold Courier label.
+extern NSString *const JDStatusBarStyleMatrix;
+/// This style has a white background with a gray Helvetica label.
+extern NSString *const JDStatusBarStyleDefault;
+/// This style has a nearly black background with a nearly white Helvetica label.
+extern NSString *const JDStatusBarStyleDark;
 
 typedef NS_ENUM(NSInteger, JDStatusBarAnimationType) {
-    JDStatusBarAnimationTypeNone,   /// Notification won't animate
-    JDStatusBarAnimationTypeMove,   /// Notification will move in from the top, and move out again to the top
-    JDStatusBarAnimationTypeBounce, /// Notification will fall down from the top and bounce a little bit
-    JDStatusBarAnimationTypeFade    /// Notification will fade in and fade out
+    /// Notification won't animate
+    JDStatusBarAnimationTypeNone,
+    /// Notification will move in from the top, and move out again to the top
+    JDStatusBarAnimationTypeMove,
+    /// Notification will fall down from the top and bounce a little bit
+    JDStatusBarAnimationTypeBounce,
+    /// Notification will fade in and fade out
+    JDStatusBarAnimationTypeFade,
 };
 
 typedef NS_ENUM(NSInteger, JDStatusBarProgressBarPosition) {
-    JDStatusBarProgressBarPositionBottom, /// progress bar will be at the bottom of the status bar
-    JDStatusBarProgressBarPositionCenter, /// progress bar will be at the center of the status bar
-    JDStatusBarProgressBarPositionTop,    /// progress bar will be at the top of the status bar
-    JDStatusBarProgressBarPositionBelow,  /// progress bar will be below the status bar (the prograss bar won't move with the statusbar in this case)
-    JDStatusBarProgressBarPositionNavBar, /// progress bar will be below the navigation bar (the prograss bar won't move with the statusbar in this case)
+    /// progress bar will be at the bottom of the status bar
+    JDStatusBarProgressBarPositionBottom,
+    /// progress bar will be at the center of the status bar
+    JDStatusBarProgressBarPositionCenter,
+    /// progress bar will be at the top of the status bar
+    JDStatusBarProgressBarPositionTop,
+    /// progress bar will be below the status bar (the progress bar won't move with the status bar in this case)
+    JDStatusBarProgressBarPositionBelow,
+    /// progress bar will be below the navigation bar (the progress bar won't move with the status bar in this case)
+    JDStatusBarProgressBarPositionNavBar,
 };
 
 /**


### PR DESCRIPTION
Before, each line of enum documentation was incorrectly being associated with the following case. For example, `JDStatusBarStyleDark` was displaying the documentation for `JDStatusBarStyleDefault` when option-clicked.

This commit fixes the issue by moving each enum case’s documentation to a separate line, before its case rather than after it.

Before:
![before](https://user-images.githubusercontent.com/2874864/32145735-a50b2252-bc8a-11e7-9141-9a1f3f1529dd.png)

After:
![after](https://user-images.githubusercontent.com/2874864/32145739-aa0e1c1e-bc8a-11e7-9a1b-9a825b4c1c7c.png)