### PR TITLE
Adjust the StatusBarNotification size for IphoneX

### DIFF
--- a/ExampleProject/JDStatusBarNotificationExample.xcodeproj/project.pbxproj
+++ b/ExampleProject/JDStatusBarNotificationExample.xcodeproj/project.pbxproj
@@ -189,11 +189,6 @@
 				CLASSPREFIX = SB;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = Markus;
-				TargetAttributes = {
-					D264F88C1820213200DA0E53 = {
-						DevelopmentTeam = 585FU3DDM6;
-					};
-				};
 			};
 			buildConfigurationList = D264F8881820213200DA0E53 /* Build configuration list for PBXProject "JDStatusBarNotificationExample" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -400,7 +395,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = 585FU3DDM6;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Prefix.pch";
 				INFOPLIST_FILE = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Info.plist";
@@ -417,7 +412,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = 585FU3DDM6;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Prefix.pch";
 				INFOPLIST_FILE = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Info.plist";

--- a/ExampleProject/JDStatusBarNotificationExample.xcodeproj/project.pbxproj
+++ b/ExampleProject/JDStatusBarNotificationExample.xcodeproj/project.pbxproj
@@ -189,6 +189,11 @@
 				CLASSPREFIX = SB;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = Markus;
+				TargetAttributes = {
+					D264F88C1820213200DA0E53 = {
+						DevelopmentTeam = 585FU3DDM6;
+					};
+				};
 			};
 			buildConfigurationList = D264F8881820213200DA0E53 /* Build configuration list for PBXProject "JDStatusBarNotificationExample" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -395,6 +400,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				DEVELOPMENT_TEAM = 585FU3DDM6;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Prefix.pch";
 				INFOPLIST_FILE = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Info.plist";
@@ -411,6 +417,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				DEVELOPMENT_TEAM = 585FU3DDM6;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Prefix.pch";
 				INFOPLIST_FILE = "JDStatusBarNotificationExample/JDStatusBarNotificationExample-Info.plist";

--- a/ExampleProject/JDStatusBarNotificationExample/SBExampleViewController.m
+++ b/ExampleProject/JDStatusBarNotificationExample/SBExampleViewController.m
@@ -70,7 +70,8 @@ static NSString *const SBStyle2 = @"SBStyle2";
                         @{JDButtonName:@"Show JDStatusBarStyleWarning", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"You know who I am!"},
                         @{JDButtonName:@"Show JDStatusBarStyleSuccess", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"That's how we roll!"},
                         @{JDButtonName:@"Show JDStatusBarStyleDark", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"Don't mess with me!"},
-                        @{JDButtonName:@"Show JDStatusBarStyleMatrix", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"Wake up Neo…"}],
+                        @{JDButtonName:@"Show JDStatusBarStyleMatrix", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"Wake up Neo…"},
+                        @{JDButtonName:@"Show JDStatusBarStyleErrorMini", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"No, I don't have the money.."}],
                       @[@{JDButtonName:@"Show custom style 1", JDButtonInfo:@"Duration: 4s, JDStatusBarAnimationTypeFade", JDNotificationText:@"Oh, I love it!"},
                         @{JDButtonName:@"Show custom style 2", JDButtonInfo:@"Duration: 4s, JDStatusBarAnimationTypeBounce", JDNotificationText:@"Level up!"}],
                       @[@{JDButtonName:@"Create your own style", JDButtonInfo:@"Test all possibilities", JDNotificationText:@""}]];
@@ -183,6 +184,8 @@ static NSString *const SBStyle2 = @"SBStyle2";
             style = JDStatusBarStyleDark;
         } else if(row == 4) {
             style = JDStatusBarStyleMatrix;
+        } else if(row == 5){
+            style = JDSTatusBarStyleErrorMini;
         }
         
         [JDStatusBarNotification showWithStatus:status

--- a/ExampleProject/JDStatusBarNotificationExample/SBExampleViewController.m
+++ b/ExampleProject/JDStatusBarNotificationExample/SBExampleViewController.m
@@ -70,8 +70,7 @@ static NSString *const SBStyle2 = @"SBStyle2";
                         @{JDButtonName:@"Show JDStatusBarStyleWarning", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"You know who I am!"},
                         @{JDButtonName:@"Show JDStatusBarStyleSuccess", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"That's how we roll!"},
                         @{JDButtonName:@"Show JDStatusBarStyleDark", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"Don't mess with me!"},
-                        @{JDButtonName:@"Show JDStatusBarStyleMatrix", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"Wake up Neo…"},
-                        @{JDButtonName:@"Show JDStatusBarStyleErrorMini", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"No, I don't have the money.."}],
+                        @{JDButtonName:@"Show JDStatusBarStyleMatrix", JDButtonInfo:@"Duration: 2s", JDNotificationText:@"Wake up Neo…"}],
                       @[@{JDButtonName:@"Show custom style 1", JDButtonInfo:@"Duration: 4s, JDStatusBarAnimationTypeFade", JDNotificationText:@"Oh, I love it!"},
                         @{JDButtonName:@"Show custom style 2", JDButtonInfo:@"Duration: 4s, JDStatusBarAnimationTypeBounce", JDNotificationText:@"Level up!"}],
                       @[@{JDButtonName:@"Create your own style", JDButtonInfo:@"Test all possibilities", JDNotificationText:@""}]];
@@ -184,8 +183,6 @@ static NSString *const SBStyle2 = @"SBStyle2";
             style = JDStatusBarStyleDark;
         } else if(row == 4) {
             style = JDStatusBarStyleMatrix;
-        } else if(row == 5){
-            style = JDStatusBarStyleErrorMini;
         }
         
         [JDStatusBarNotification showWithStatus:status

--- a/ExampleProject/JDStatusBarNotificationExample/SBExampleViewController.m
+++ b/ExampleProject/JDStatusBarNotificationExample/SBExampleViewController.m
@@ -185,7 +185,7 @@ static NSString *const SBStyle2 = @"SBStyle2";
         } else if(row == 4) {
             style = JDStatusBarStyleMatrix;
         } else if(row == 5){
-            style = JDSTatusBarStyleErrorMini;
+            style = JDStatusBarStyleErrorMini;
         }
         
         [JDStatusBarNotification showWithStatus:status

--- a/ExampleProject/Pods/Pods.xcodeproj/project.pbxproj
+++ b/ExampleProject/Pods/Pods.xcodeproj/project.pbxproj
@@ -441,241 +441,48 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		0FAFFAC801E8142EE45DA70B22DE20F2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 03471F1BEFC2B5CA2CB337026203685A /* FTFontSelector.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/FTFontSelector/FTFontSelector-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		25BC4604B2E4BAA73827FC4B0BE72EBD /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 03471F1BEFC2B5CA2CB337026203685A /* FTFontSelector.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/FTFontSelector/FTFontSelector-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		8705BAC537A1AE6EF6119BBCE365C8B0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 76D8CE2534BE3A5D63126B7D920A6636 /* Pods-JDStatusBarNotificationExample.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACH_O_TYPE = staticlib;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		995C12DF727BBF7F4521CDC2E04EC64C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0C6C2FD1965C10C77F318BE3B8D446CF /* InfColorPicker.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/InfColorPicker/InfColorPicker-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		A63ED074089080ACB9C18537E744F3E9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0C6C2FD1965C10C77F318BE3B8D446CF /* InfColorPicker.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/InfColorPicker/InfColorPicker-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		B254DAA6CF0CE39F4A3D11B90A7E059A /* Release */ = {
+		1C7D17A37D091C98D2F0DD886C3A9320 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"POD_CONFIGURATION_RELEASE=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = NO_SIGNING/;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-			};
-			name = Release;
-		};
-		B796FD9A2BED810504BD06A65C69BBA5 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1D3C5A97F00A3B68EDF369F935513F13 /* Pods-JDStatusBarNotificationExample.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACH_O_TYPE = staticlib;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		E4B68EE12B21C47CB798D9B1ECA6D7A7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_DEBUG=1",
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = NO_SIGNING/;
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -683,14 +490,200 @@
 			};
 			name = Debug;
 		};
+		2DB520DE5CB187B1F07E9A9AB438C958 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 76D8CE2534BE3A5D63126B7D920A6636 /* Pods-JDStatusBarNotificationExample.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACH_O_TYPE = staticlib;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		34FE9531DA9AF2820790339988D5FF41 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"POD_CONFIGURATION_RELEASE=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				PROVISIONING_PROFILE_SPECIFIER = NO_SIGNING/;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4929A64E245C036A8A800BDE4119CBBA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 03471F1BEFC2B5CA2CB337026203685A /* FTFontSelector.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FTFontSelector/FTFontSelector-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+			};
+			name = Debug;
+		};
+		624D9DCE1FF99B79AFF4AFA672C95F7B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0C6C2FD1965C10C77F318BE3B8D446CF /* InfColorPicker.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/InfColorPicker/InfColorPicker-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+			};
+			name = Debug;
+		};
+		8C9ABB0578C85D71B161F6967A868F53 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D3C5A97F00A3B68EDF369F935513F13 /* Pods-JDStatusBarNotificationExample.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACH_O_TYPE = staticlib;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		CF7F94E6B0BCD9E7280A6331201713B4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0C6C2FD1965C10C77F318BE3B8D446CF /* InfColorPicker.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/InfColorPicker/InfColorPicker-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+			};
+			name = Release;
+		};
+		E952FD14D70D787C286D26A02EA70654 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 03471F1BEFC2B5CA2CB337026203685A /* FTFontSelector.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/FTFontSelector/FTFontSelector-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
 		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E4B68EE12B21C47CB798D9B1ECA6D7A7 /* Debug */,
-				B254DAA6CF0CE39F4A3D11B90A7E059A /* Release */,
+				1C7D17A37D091C98D2F0DD886C3A9320 /* Debug */,
+				34FE9531DA9AF2820790339988D5FF41 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -698,8 +691,8 @@
 		7891031930B71E6EC9EA01FB730842DC /* Build configuration list for PBXNativeTarget "Pods-JDStatusBarNotificationExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B796FD9A2BED810504BD06A65C69BBA5 /* Debug */,
-				8705BAC537A1AE6EF6119BBCE365C8B0 /* Release */,
+				8C9ABB0578C85D71B161F6967A868F53 /* Debug */,
+				2DB520DE5CB187B1F07E9A9AB438C958 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -707,8 +700,8 @@
 		96D3955B557F2C49449069B567D48EB0 /* Build configuration list for PBXNativeTarget "FTFontSelector" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				25BC4604B2E4BAA73827FC4B0BE72EBD /* Debug */,
-				0FAFFAC801E8142EE45DA70B22DE20F2 /* Release */,
+				4929A64E245C036A8A800BDE4119CBBA /* Debug */,
+				E952FD14D70D787C286D26A02EA70654 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -716,8 +709,8 @@
 		B69031E104326458DFA6A0D117539D9A /* Build configuration list for PBXNativeTarget "InfColorPicker" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A63ED074089080ACB9C18537E744F3E9 /* Debug */,
-				995C12DF727BBF7F4521CDC2E04EC64C /* Release */,
+				624D9DCE1FF99B79AFF4AFA672C95F7B /* Debug */,
+				CF7F94E6B0BCD9E7280A6331201713B4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/JDStatusBarNotification.xcodeproj/project.pbxproj
+++ b/JDStatusBarNotification.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		72ED904B1F86D97B00AF41F7 /* JDStatusBarStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 72ED90461F86D97B00AF41F7 /* JDStatusBarStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72ED904C1F86D97B00AF41F7 /* JDStatusBarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 72ED90471F86D97B00AF41F7 /* JDStatusBarView.m */; };
 		72ED904D1F86D97B00AF41F7 /* JDStatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 72ED90481F86D97B00AF41F7 /* JDStatusBarStyle.m */; };
-		72ED904F1F86D98500AF41F7 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 72ED904E1F86D98500AF41F7 /* Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -108,7 +107,7 @@
 		72ED90301F86D92A00AF41F7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0920;
 				TargetAttributes = {
 					72ED90381F86D92A00AF41F7 = {
 						CreatedOnToolsVersion = 9.0;
@@ -138,7 +137,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72ED904F1F86D98500AF41F7 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JDStatusBarNotification.xcodeproj/xcshareddata/xcschemes/JDStatusBarNotification.xcscheme
+++ b/JDStatusBarNotification.xcodeproj/xcshareddata/xcschemes/JDStatusBarNotification.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -458,6 +458,7 @@
     } else {
       self.topBar.alpha = 0.0;
     }
+      self.topBar.iphoneXSize = style.iphoneXSize;
   }
   return _topBar;
 }
@@ -494,7 +495,12 @@
   // adjust for iPhone X
   CGFloat topLayoutMargin = JDStatusBarRootVCLayoutMargin().top;
   if (topLayoutMargin > 0) {
-    height += topLayoutMargin;
+      JDStatusBarStyle *style = self.activeStyle ?: self.defaultStyle;
+      if (style.iphoneXSize == JDStatusBarIphoneXSizeBig){
+          height += topLayoutMargin;
+      } else {
+          height += 8.0;
+      }
   }
 
   _topBar.frame = CGRectMake(0, yPos, width, height);

--- a/JDStatusBarNotification/JDStatusBarStyle.h
+++ b/JDStatusBarNotification/JDStatusBarStyle.h
@@ -22,10 +22,6 @@ extern NSString *const JDStatusBarStyleDefault;
 /// This style has a nearly black background with a nearly white Helvetica label.
 extern NSString *const JDStatusBarStyleDark;
 
-/// This style has a red backbround with a white Helvetica label. For iPhone X, the size of
-/// the notification status bar is minimize to show the navigation bar
-extern NSString *const JDStatusBarStyleErrorMini;
-
 typedef NS_ENUM(NSInteger, JDStatusBarAnimationType) {
     /// Notification won't animate
     JDStatusBarAnimationTypeNone,

--- a/JDStatusBarNotification/JDStatusBarStyle.h
+++ b/JDStatusBarNotification/JDStatusBarStyle.h
@@ -24,7 +24,7 @@ extern NSString *const JDStatusBarStyleDark;
 
 /// This style has a red backbround with a white Helvetica label. For iPhone X, the size of
 /// the notification status bar is minimize to show the navigation bar
-extern NSString *const JDSTatusBarStyleErrorMini;
+extern NSString *const JDStatusBarStyleErrorMini;
 
 typedef NS_ENUM(NSInteger, JDStatusBarAnimationType) {
     /// Notification won't animate

--- a/JDStatusBarNotification/JDStatusBarStyle.h
+++ b/JDStatusBarNotification/JDStatusBarStyle.h
@@ -22,6 +22,10 @@ extern NSString *const JDStatusBarStyleDefault;
 /// This style has a nearly black background with a nearly white Helvetica label.
 extern NSString *const JDStatusBarStyleDark;
 
+/// This style has a red backbround with a white Helvetica label. For iPhone X, the size of
+/// the notification status bar is minimize to show the navigation bar
+extern NSString *const JDSTatusBarStyleErrorMini;
+
 typedef NS_ENUM(NSInteger, JDStatusBarAnimationType) {
     /// Notification won't animate
     JDStatusBarAnimationTypeNone,
@@ -44,6 +48,13 @@ typedef NS_ENUM(NSInteger, JDStatusBarProgressBarPosition) {
     JDStatusBarProgressBarPositionBelow,
     /// progress bar will be below the navigation bar (the progress bar won't move with the status bar in this case)
     JDStatusBarProgressBarPositionNavBar,
+};
+
+typedef NS_ENUM(NSInteger, JDStatusBarIphoneXSize) {
+    /// the size of the status bar is minimize to show the navigation bar
+    JDStatusBarIphoneXSizeMini,
+    /// the size of the status bar is bigger to hide the navigation bar
+    JDStatusBarIphoneXSizeBig,
 };
 
 /**
@@ -87,6 +98,10 @@ typedef NS_ENUM(NSInteger, JDStatusBarProgressBarPosition) {
 
 /// The corner radius of the progress bar. Default is 0.0
 @property (nonatomic, assign) CGFloat progressBarCornerRadius;
+
+#pragma mark Iphone X Size
+
+@property (nonatomic, assign) JDStatusBarIphoneXSize iphoneXSize;
 
 @end
 

--- a/JDStatusBarNotification/JDStatusBarStyle.m
+++ b/JDStatusBarNotification/JDStatusBarStyle.m
@@ -14,7 +14,7 @@ NSString *const JDStatusBarStyleSuccess     = @"JDStatusBarStyleSuccess";
 NSString *const JDStatusBarStyleMatrix      = @"JDStatusBarStyleMatrix";
 NSString *const JDStatusBarStyleDefault     = @"JDStatusBarStyleDefault";
 NSString *const JDStatusBarStyleDark        = @"JDStatusBarStyleDark";
-NSString *const JDSTatusBarStyleErrorMini   = @"JDSTatusBarStyleErrorMini";
+NSString *const JDStatusBarStyleErrorMini   = @"JDStatusBarStyleErrorMini";
 
 @implementation JDStatusBarStyle
 
@@ -38,7 +38,7 @@ NSString *const JDSTatusBarStyleErrorMini   = @"JDSTatusBarStyleErrorMini";
 {
   return @[JDStatusBarStyleError, JDStatusBarStyleWarning,
            JDStatusBarStyleSuccess, JDStatusBarStyleMatrix,
-           JDStatusBarStyleDark, JDSTatusBarStyleErrorMini];
+           JDStatusBarStyleDark, JDStatusBarStyleErrorMini];
 }
 
 + (JDStatusBarStyle*)defaultStyleWithName:(NSString*)styleName;
@@ -104,7 +104,7 @@ NSString *const JDSTatusBarStyleErrorMini   = @"JDSTatusBarStyleErrorMini";
   }
 
     // JDStatusBarStyleErrorMini
-  else if ([styleName isEqualToString:JDSTatusBarStyleErrorMini]) {
+  else if ([styleName isEqualToString:JDStatusBarStyleErrorMini]) {
       style.barColor = [UIColor colorWithRed:0.588 green:0.118 blue:0.000 alpha:1.000];
       style.textColor = [UIColor whiteColor];
       style.progressBarColor = [UIColor redColor];

--- a/JDStatusBarNotification/JDStatusBarStyle.m
+++ b/JDStatusBarNotification/JDStatusBarStyle.m
@@ -8,12 +8,13 @@
 
 #import "JDStatusBarStyle.h"
 
-NSString *const JDStatusBarStyleError   = @"JDStatusBarStyleError";
-NSString *const JDStatusBarStyleWarning = @"JDStatusBarStyleWarning";
-NSString *const JDStatusBarStyleSuccess = @"JDStatusBarStyleSuccess";
-NSString *const JDStatusBarStyleMatrix  = @"JDStatusBarStyleMatrix";
-NSString *const JDStatusBarStyleDefault = @"JDStatusBarStyleDefault";
-NSString *const JDStatusBarStyleDark    = @"JDStatusBarStyleDark";
+NSString *const JDStatusBarStyleError       = @"JDStatusBarStyleError";
+NSString *const JDStatusBarStyleWarning     = @"JDStatusBarStyleWarning";
+NSString *const JDStatusBarStyleSuccess     = @"JDStatusBarStyleSuccess";
+NSString *const JDStatusBarStyleMatrix      = @"JDStatusBarStyleMatrix";
+NSString *const JDStatusBarStyleDefault     = @"JDStatusBarStyleDefault";
+NSString *const JDStatusBarStyleDark        = @"JDStatusBarStyleDark";
+NSString *const JDSTatusBarStyleErrorMini   = @"JDSTatusBarStyleErrorMini";
 
 @implementation JDStatusBarStyle
 
@@ -29,6 +30,7 @@ NSString *const JDStatusBarStyleDark    = @"JDStatusBarStyleDark";
   style.progressBarColor = self.progressBarColor;
   style.progressBarHeight = self.progressBarHeight;
   style.progressBarPosition = self.progressBarPosition;
+  style.iphoneXSize = self.iphoneXSize;
   return style;
 }
 
@@ -36,7 +38,7 @@ NSString *const JDStatusBarStyleDark    = @"JDStatusBarStyleDark";
 {
   return @[JDStatusBarStyleError, JDStatusBarStyleWarning,
            JDStatusBarStyleSuccess, JDStatusBarStyleMatrix,
-           JDStatusBarStyleDark];
+           JDStatusBarStyleDark, JDSTatusBarStyleErrorMini];
 }
 
 + (JDStatusBarStyle*)defaultStyleWithName:(NSString*)styleName;
@@ -50,6 +52,7 @@ NSString *const JDStatusBarStyleDark    = @"JDStatusBarStyleDark";
   style.textColor = [UIColor grayColor];
   style.font = [UIFont systemFontOfSize:12.0];
   style.animationType = JDStatusBarAnimationTypeMove;
+  style.iphoneXSize = JDStatusBarIphoneXSizeBig;
 
   // JDStatusBarStyleDefault
   if ([styleName isEqualToString:JDStatusBarStyleDefault]) {
@@ -100,6 +103,16 @@ NSString *const JDStatusBarStyleDark    = @"JDStatusBarStyleDark";
     return style;
   }
 
+    // JDStatusBarStyleErrorMini
+  else if ([styleName isEqualToString:JDSTatusBarStyleErrorMini]) {
+      style.barColor = [UIColor colorWithRed:0.588 green:0.118 blue:0.000 alpha:1.000];
+      style.textColor = [UIColor whiteColor];
+      style.progressBarColor = [UIColor redColor];
+      style.progressBarHeight = 2.0;
+      style.iphoneXSize = JDStatusBarIphoneXSizeMini;
+      return style;
+  }
+    
   return nil;
 }
 

--- a/JDStatusBarNotification/JDStatusBarStyle.m
+++ b/JDStatusBarNotification/JDStatusBarStyle.m
@@ -14,7 +14,6 @@ NSString *const JDStatusBarStyleSuccess     = @"JDStatusBarStyleSuccess";
 NSString *const JDStatusBarStyleMatrix      = @"JDStatusBarStyleMatrix";
 NSString *const JDStatusBarStyleDefault     = @"JDStatusBarStyleDefault";
 NSString *const JDStatusBarStyleDark        = @"JDStatusBarStyleDark";
-NSString *const JDStatusBarStyleErrorMini   = @"JDStatusBarStyleErrorMini";
 
 @implementation JDStatusBarStyle
 
@@ -38,7 +37,7 @@ NSString *const JDStatusBarStyleErrorMini   = @"JDStatusBarStyleErrorMini";
 {
   return @[JDStatusBarStyleError, JDStatusBarStyleWarning,
            JDStatusBarStyleSuccess, JDStatusBarStyleMatrix,
-           JDStatusBarStyleDark, JDStatusBarStyleErrorMini];
+           JDStatusBarStyleDark];
 }
 
 + (JDStatusBarStyle*)defaultStyleWithName:(NSString*)styleName;
@@ -101,16 +100,6 @@ NSString *const JDStatusBarStyleErrorMini   = @"JDStatusBarStyleErrorMini";
     style.progressBarColor = [UIColor greenColor];
     style.progressBarHeight = 2.0;
     return style;
-  }
-
-    // JDStatusBarStyleErrorMini
-  else if ([styleName isEqualToString:JDStatusBarStyleErrorMini]) {
-      style.barColor = [UIColor colorWithRed:0.588 green:0.118 blue:0.000 alpha:1.000];
-      style.textColor = [UIColor whiteColor];
-      style.progressBarColor = [UIColor redColor];
-      style.progressBarHeight = 2.0;
-      style.iphoneXSize = JDStatusBarIphoneXSizeMini;
-      return style;
   }
     
   return nil;

--- a/JDStatusBarNotification/JDStatusBarStyle.m
+++ b/JDStatusBarNotification/JDStatusBarStyle.m
@@ -8,12 +8,12 @@
 
 #import "JDStatusBarStyle.h"
 
-NSString *const JDStatusBarStyleError       = @"JDStatusBarStyleError";
-NSString *const JDStatusBarStyleWarning     = @"JDStatusBarStyleWarning";
-NSString *const JDStatusBarStyleSuccess     = @"JDStatusBarStyleSuccess";
-NSString *const JDStatusBarStyleMatrix      = @"JDStatusBarStyleMatrix";
-NSString *const JDStatusBarStyleDefault     = @"JDStatusBarStyleDefault";
-NSString *const JDStatusBarStyleDark        = @"JDStatusBarStyleDark";
+NSString *const JDStatusBarStyleError   = @"JDStatusBarStyleError";
+NSString *const JDStatusBarStyleWarning = @"JDStatusBarStyleWarning";
+NSString *const JDStatusBarStyleSuccess = @"JDStatusBarStyleSuccess";
+NSString *const JDStatusBarStyleMatrix  = @"JDStatusBarStyleMatrix";
+NSString *const JDStatusBarStyleDefault = @"JDStatusBarStyleDefault";
+NSString *const JDStatusBarStyleDark    = @"JDStatusBarStyleDark";
 
 @implementation JDStatusBarStyle
 

--- a/JDStatusBarNotification/JDStatusBarView.h
+++ b/JDStatusBarNotification/JDStatusBarView.h
@@ -7,9 +7,11 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "JDStatusBarStyle.h"
 
 @interface JDStatusBarView : UIView
 @property (nonatomic, strong, readonly) UILabel *textLabel;
 @property (nonatomic, strong, readonly) UIActivityIndicatorView *activityIndicatorView;
 @property (nonatomic, assign) CGFloat textVerticalPositionAdjustment;
+@property (nonatomic, assign) JDStatusBarIphoneXSize iphoneXSize;
 @end

--- a/JDStatusBarNotification/JDStatusBarView.m
+++ b/JDStatusBarNotification/JDStatusBarView.m
@@ -64,10 +64,14 @@
     
     // adjust for iPhone X
     if (topLayoutMargin > 0){
-        if (_iphoneXSize == JDStatusBarIphoneXSizeMini){
-            labelY = self.textVerticalPositionAdjustment + topLayoutMargin - 8.0 - 3.0; // 3.0 to adjust correctly the label
-            height = self.bounds.size.height - topLayoutMargin + 8.0;
-        }
+		switch (_iphoneXSize) {
+			case JDStatusBarIphoneXSizeMini:
+				labelY = self.textVerticalPositionAdjustment + topLayoutMargin - 8.0 - 3.0; // 3.0 to adjust correctly the label
+				height = self.bounds.size.height - topLayoutMargin + 8.0;
+				break;
+			default:
+				break;
+		}
     }
     
   self.textLabel.frame = CGRectMake(0,
@@ -79,13 +83,17 @@
   if (_activityIndicatorView ) {
     CGSize textSize = [self currentTextSize];
     CGRect indicatorFrame = _activityIndicatorView.frame;
-    indicatorFrame.origin.x = round((self.bounds.size.width - textSize.width)/2.0) - indicatorFrame.size.width - 8.0;
+    indicatorFrame.origin.x = round((_textLabel.bounds.size.width - textSize.width)/2.0) - indicatorFrame.size.width - 8.0;
     
     CGFloat indicatorY = ceil(1+(self.bounds.size.height - indicatorFrame.size.height + topLayoutMargin)/2.0);
     if (topLayoutMargin > 0){
-        if(_iphoneXSize == JDStatusBarIphoneXSizeMini){
-            indicatorY = self.bounds.size.height - indicatorFrame.size.height - 8.0/2;
-        }
+		switch (_iphoneXSize) {
+			case JDStatusBarIphoneXSizeMini:
+				indicatorY = self.bounds.size.height - indicatorFrame.size.height - 8.0/2;
+				break;
+			default:
+				break;
+		}
     }
       
     indicatorFrame.origin.y = indicatorY;

--- a/JDStatusBarNotification/JDStatusBarView.m
+++ b/JDStatusBarNotification/JDStatusBarView.m
@@ -66,7 +66,7 @@
     if (topLayoutMargin > 0){
 		switch (_iphoneXSize) {
 			case JDStatusBarIphoneXSizeMini:
-				labelY = self.textVerticalPositionAdjustment + topLayoutMargin - 8.0 - 3.0; // 3.0 to adjust correctly the label
+			labelY -= 12;
 				height = self.bounds.size.height - topLayoutMargin + 8.0;
 				break;
 			default:
@@ -83,7 +83,7 @@
   if (_activityIndicatorView ) {
     CGSize textSize = [self currentTextSize];
     CGRect indicatorFrame = _activityIndicatorView.frame;
-    indicatorFrame.origin.x = round((_textLabel.bounds.size.width - textSize.width)/2.0) - indicatorFrame.size.width - 8.0;
+    indicatorFrame.origin.x = round((self.bounds.size.width - textSize.width)/2.0) - indicatorFrame.size.width - 8.0;
     
     CGFloat indicatorY = ceil(1+(self.bounds.size.height - indicatorFrame.size.height + topLayoutMargin)/2.0);
     if (topLayoutMargin > 0){

--- a/JDStatusBarNotification/JDStatusBarView.m
+++ b/JDStatusBarNotification/JDStatusBarView.m
@@ -58,17 +58,37 @@
 
   // label
   CGFloat topLayoutMargin = JDStatusBarRootVCLayoutMargin().top;
+    
+    CGFloat labelY = self.textVerticalPositionAdjustment + topLayoutMargin + 1;
+    CGFloat height = self.bounds.size.height - topLayoutMargin - 1;
+    
+    // adjust for iPhone X
+    if (topLayoutMargin > 0){
+        if (_iphoneXSize == JDStatusBarIphoneXSizeMini){
+            labelY = self.textVerticalPositionAdjustment + topLayoutMargin - 8.0 - 3.0; // 3.0 to adjust correctly the label
+            height = self.bounds.size.height - topLayoutMargin + 8.0;
+        }
+    }
+    
   self.textLabel.frame = CGRectMake(0,
-                                    self.textVerticalPositionAdjustment + topLayoutMargin + 1,
+                                    labelY,
                                     self.bounds.size.width,
-                                    self.bounds.size.height - topLayoutMargin - 1);
+                                    height);
 
   // activity indicator
   if (_activityIndicatorView ) {
     CGSize textSize = [self currentTextSize];
     CGRect indicatorFrame = _activityIndicatorView.frame;
     indicatorFrame.origin.x = round((self.bounds.size.width - textSize.width)/2.0) - indicatorFrame.size.width - 8.0;
-    indicatorFrame.origin.y = ceil(1+(self.bounds.size.height - indicatorFrame.size.height + topLayoutMargin)/2.0);
+    
+    CGFloat indicatorY = ceil(1+(self.bounds.size.height - indicatorFrame.size.height + topLayoutMargin)/2.0);
+    if (topLayoutMargin > 0){
+        if(_iphoneXSize == JDStatusBarIphoneXSizeMini){
+            indicatorY = self.bounds.size.height - indicatorFrame.size.height - 8.0/2;
+        }
+    }
+      
+    indicatorFrame.origin.y = indicatorY;
     _activityIndicatorView.frame = indicatorFrame;
   }
 }


### PR DESCRIPTION
Hi,

I fork your project and and i modify the size of the status bar notification for iPhone.

I add a variable (iphoneXSize the name can be modified) in JDStatusBarStyle.
This variable helps to define the size of the status bar notification.

If the variable _iphoneXSize_ is Mini (**JDStatusBarIphoneXSizeMini**) the status bar notification will pop on the status bar with a extra space to keep the title of the navigation bar visible and the back button visible to.

![iphonex-mini](https://user-images.githubusercontent.com/5968328/33933162-2f14f382-dff5-11e7-814e-5f47c028891b.png)

By default, the variable _iphoneXSize_ is Big (**JDStatusBarIphoneXSizeBig**), the status bar notification will pop above the navigation bar. It's the same behavior of the current version of the lib.

![iphonex-big](https://user-images.githubusercontent.com/5968328/33933201-49c4f6dc-dff5-11e7-8e13-abe2153cc305.png)



