### PR TITLE
fix: hide statusbar when showing on iOS 13 so that it does not cover the banner

### DIFF
--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -620,7 +620,7 @@ static BOOL JDUIViewControllerBasedStatusBarAppearanceEnabled() {
 }
 
 - (BOOL)prefersStatusBarHidden {
-  return NO;
+  return @available(iOS 13, *) && JDStatusBarRootVCLayoutMargin().top == 0;
 }
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation {


### PR DESCRIPTION
Fix for issue #110 