### PR TITLE
Update minimum iOS version supported to iOS 9

### DIFF
--- a/JDStatusBarNotification.podspec
+++ b/JDStatusBarNotification.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   
   s.name         = 'JDStatusBarNotification'
-  s.version      = '1.6.1'
+  s.version      = '1.7.0'
   s.summary      = 'Easy, customizable notifications displayed on top of the statusbar. With progress and activity. iPhone X ready.'
 
   s.description  = 'Show messages on top of the status bar. Customizable colors, font and animation. Supports progress display and can show an activity indicator. Supports iOS 6+ and iPhone X.'
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source_files = 'JDStatusBarNotification/**'
   s.frameworks   = 'QuartzCore'
   
-  s.platform     = :ios, '6.0'
+  s.platform     = :ios, '9.0'
   s.requires_arc = true
 
 end


### PR DESCRIPTION
Starting XCode 12, the minimum iOS supported version is 9 and iOS 8 is not supported anymore. Currently a warning is produced by XCode about deployment target - so bumping minimum version to lowest supported will fix it.

I don't think there will be many users using less than iOS 9 anyways.