### PR TITLE
Fix logic issue about defaultStyle

### DIFF
--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -28,6 +28,10 @@ class StyleCache: NSObject {
     defaultStyle = styleBuilder(defaultStyle)
   }
 
+  func resetDefaultStyle() {
+    defaultStyle = StatusBarNotificationStyle()
+  }
+
   func addStyleNamed(_ styleName: String,
                      basedOnStyle includedStyle: IncludedStatusBarNotificationStyle,
                      prepare styleBuilder: NotificationPresenter.PrepareStyleClosure) -> String

--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -28,10 +28,6 @@ class StyleCache: NSObject {
     defaultStyle = styleBuilder(defaultStyle)
   }
 
-  func resetDefaultStyle() {
-    defaultStyle = StatusBarNotificationStyle()
-  }
-
   func addStyleNamed(_ styleName: String,
                      basedOnStyle includedStyle: IncludedStatusBarNotificationStyle,
                      prepare styleBuilder: NotificationPresenter.PrepareStyleClosure) -> String

--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -10,8 +10,8 @@ import Foundation
 import UIKit
 
 class StyleCache: NSObject {
-  var defaultStyle: StatusBarNotificationStyle = StatusBarNotificationStyle()
-  var userStyles: [String: StatusBarNotificationStyle] = [:]
+  private(set) var defaultStyle: StatusBarNotificationStyle = StatusBarNotificationStyle()
+  private(set) var userStyles: [String: StatusBarNotificationStyle] = [:]
 
   func style(forName styleName: String?) -> StatusBarNotificationStyle {
     if let styleName, let style = userStyles[styleName] {
@@ -26,6 +26,10 @@ class StyleCache: NSObject {
 
   func updateDefaultStyle(_ styleBuilder: NotificationPresenter.PrepareStyleClosure) {
     defaultStyle = styleBuilder(defaultStyle)
+  }
+
+  func resetDefaultStyle() {
+    defaultStyle = StatusBarNotificationStyle()
   }
 
   func addStyleNamed(_ styleName: String,

--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -30,6 +30,9 @@ class StyleCache: NSObject {
 
   func resetDefaultStyle() {
     defaultStyle = StatusBarNotificationStyle()
+    if let index = userStyles.firstIndex(where: { $0.value.systemStatusBarStyle == .defaultStyle }) {
+        userStyles.remove(at: index)
+    }
   }
 
   func addStyleNamed(_ styleName: String,

--- a/JDStatusBarNotification/Public/NotificationPresenter.swift
+++ b/JDStatusBarNotification/Public/NotificationPresenter.swift
@@ -203,7 +203,7 @@ public class NotificationPresenter: NSObject, NotificationWindowDelegate {
     overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: { [weak self] in
       guard let self else { return }
       if self.styleCache.userStyles.contains(where: { $0.value.systemStatusBarStyle == .defaultStyle }) {
-          self.styleCache.resetDefaultStyle()
+          self.styleCache.updateDefaultStyle { _ in return StatusBarNotificationStyle() }
       }
       completion?(self)
     })

--- a/JDStatusBarNotification/Public/NotificationPresenter.swift
+++ b/JDStatusBarNotification/Public/NotificationPresenter.swift
@@ -200,7 +200,9 @@ public class NotificationPresenter: NSObject, NotificationWindowDelegate {
   ///   - completion: A ``Completion`` closure, which gets called once the dismiss animation finishes.
   ///
   public func dismiss(animated: Bool = true, after delay: Double? = nil, completion: Completion? = nil) {
-    overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: {
+    overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: { [weak self] in
+      guard let self else { return }
+      self.styleCache.resetDefaultStyle()
       completion?(self)
     })
   }

--- a/JDStatusBarNotification/Public/NotificationPresenter.swift
+++ b/JDStatusBarNotification/Public/NotificationPresenter.swift
@@ -203,7 +203,7 @@ public class NotificationPresenter: NSObject, NotificationWindowDelegate {
     overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: { [weak self] in
       guard let self else { return }
       if self.styleCache.userStyles.contains(where: { $0.value.systemStatusBarStyle == .defaultStyle }) {
-          self.styleCache.updateDefaultStyle { _ in return StatusBarNotificationStyle() }
+          self.styleCache.resetDefaultStyle()
       }
       completion?(self)
     })

--- a/JDStatusBarNotification/Public/NotificationPresenter.swift
+++ b/JDStatusBarNotification/Public/NotificationPresenter.swift
@@ -202,7 +202,9 @@ public class NotificationPresenter: NSObject, NotificationWindowDelegate {
   public func dismiss(animated: Bool = true, after delay: Double? = nil, completion: Completion? = nil) {
     overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: { [weak self] in
       guard let self else { return }
-      self.styleCache.resetDefaultStyle()
+      if self.styleCache.userStyles.contains(where: { $0.value.systemStatusBarStyle == .defaultStyle }) {
+          self.styleCache.resetDefaultStyle()
+      }
       completion?(self)
     })
   }


### PR DESCRIPTION
Please look at gif below:

![twincircle](https://github.com/calimarkus/JDStatusBarNotification/assets/17738992/aae2a579-d2e0-412a-a7b4-45d2a499634c)

Since the first time you use `NotificationPresenter`, some attribute values of `defaultStyle` are modified. If you use other types of NotificationPresenter next time, and the usingStyle is defaultStyle, the value of defaultStyle will still retain the value used last time. So `defaultStyle` needs to be reset to its default value when NotificationPresenter dismiss.