### PR TITLE
Fix logic issue about defaultStyle 

### DIFF
--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -10,14 +10,16 @@ import Foundation
 import UIKit
 
 class StyleCache: NSObject {
-  private(set) var defaultStyle: StatusBarNotificationStyle = StatusBarNotificationStyle()
+
+  private var styleName: String = "defaultStyleName"
+  private let defaultStyle: StatusBarNotificationStyle = StatusBarNotificationStyle()
   private(set) var userStyles: [String: StatusBarNotificationStyle] = [:]
 
   func style(forName styleName: String?) -> StatusBarNotificationStyle {
     if let styleName, let style = userStyles[styleName] {
       return style
     }
-    return defaultStyle
+    return userStyles[self.styleName] ?? defaultStyle
   }
 
   func style(forIncludedStyle includedStyle: IncludedStatusBarNotificationStyle) -> StatusBarNotificationStyle {
@@ -25,17 +27,19 @@ class StyleCache: NSObject {
   }
 
   func updateDefaultStyle(_ styleBuilder: NotificationPresenter.PrepareStyleClosure) {
-    defaultStyle = styleBuilder(defaultStyle)
+    guard var style = userStyles[styleName] else { return }
+    style = styleBuilder(style)
   }
 
   func resetDefaultStyle() {
-    defaultStyle = StatusBarNotificationStyle()
+      userStyles[styleName] = StatusBarNotificationStyle()
   }
 
   func addStyleNamed(_ styleName: String,
                      basedOnStyle includedStyle: IncludedStatusBarNotificationStyle,
                      prepare styleBuilder: NotificationPresenter.PrepareStyleClosure) -> String
   {
+    self.styleName = styleName
     userStyles[styleName] = styleBuilder(style(forIncludedStyle: includedStyle))
     return styleName
   }
@@ -45,7 +49,7 @@ class StyleCache: NSObject {
   private func buildStyleForIncludedStyle(_ includedStyle: IncludedStatusBarNotificationStyle) -> StatusBarNotificationStyle {
       switch includedStyle {
       case .defaultStyle:
-          return defaultStyle
+          return StatusBarNotificationStyle()
 
       case .light:
           let style = StatusBarNotificationStyle()

--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -31,10 +31,6 @@ class StyleCache: NSObject {
     style = styleBuilder(style)
   }
 
-  func resetDefaultStyle() {
-      userStyles[styleName] = StatusBarNotificationStyle()
-  }
-
   func addStyleNamed(_ styleName: String,
                      basedOnStyle includedStyle: IncludedStatusBarNotificationStyle,
                      prepare styleBuilder: NotificationPresenter.PrepareStyleClosure) -> String

--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -10,8 +10,8 @@ import Foundation
 import UIKit
 
 class StyleCache: NSObject {
-  var defaultStyle: StatusBarNotificationStyle = StatusBarNotificationStyle()
-  var userStyles: [String: StatusBarNotificationStyle] = [:]
+  private(set) var defaultStyle: StatusBarNotificationStyle = StatusBarNotificationStyle()
+  private(set) var userStyles: [String: StatusBarNotificationStyle] = [:]
 
   func style(forName styleName: String?) -> StatusBarNotificationStyle {
     if let styleName, let style = userStyles[styleName] {
@@ -26,6 +26,10 @@ class StyleCache: NSObject {
 
   func updateDefaultStyle(_ styleBuilder: NotificationPresenter.PrepareStyleClosure) {
     defaultStyle = styleBuilder(defaultStyle)
+  }
+
+  func resetDefaultStyle() {
+    defaultStyle = StatusBarNotificationStyle()
   }
 
   func addStyleNamed(_ styleName: String,

--- a/JDStatusBarNotification/Private/StyleCache.swift
+++ b/JDStatusBarNotification/Private/StyleCache.swift
@@ -10,16 +10,14 @@ import Foundation
 import UIKit
 
 class StyleCache: NSObject {
-
-  private var styleName: String = "defaultStyleName"
-  private let defaultStyle: StatusBarNotificationStyle = StatusBarNotificationStyle()
+  private var styleName: String = "styleName"
   private(set) var userStyles: [String: StatusBarNotificationStyle] = [:]
 
   func style(forName styleName: String?) -> StatusBarNotificationStyle {
     if let styleName, let style = userStyles[styleName] {
       return style
     }
-    return userStyles[self.styleName] ?? defaultStyle
+    return userStyles[self.styleName] ?? StatusBarNotificationStyle()
   }
 
   func style(forIncludedStyle includedStyle: IncludedStatusBarNotificationStyle) -> StatusBarNotificationStyle {

--- a/JDStatusBarNotification/Public/NotificationPresenter.swift
+++ b/JDStatusBarNotification/Public/NotificationPresenter.swift
@@ -200,11 +200,7 @@ public class NotificationPresenter: NSObject, NotificationWindowDelegate {
   ///   - completion: A ``Completion`` closure, which gets called once the dismiss animation finishes.
   ///
   public func dismiss(animated: Bool = true, after delay: Double? = nil, completion: Completion? = nil) {
-    overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: { [weak self] in
-      guard let self else { return }
-      if self.styleCache.userStyles.contains(where: { $0.value.systemStatusBarStyle == .defaultStyle }) {
-         self.styleCache.resetDefaultStyle()
-      }
+    overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: {
       completion?(self)
     })
   }

--- a/JDStatusBarNotification/Public/NotificationPresenter.swift
+++ b/JDStatusBarNotification/Public/NotificationPresenter.swift
@@ -200,7 +200,11 @@ public class NotificationPresenter: NSObject, NotificationWindowDelegate {
   ///   - completion: A ``Completion`` closure, which gets called once the dismiss animation finishes.
   ///
   public func dismiss(animated: Bool = true, after delay: Double? = nil, completion: Completion? = nil) {
-    overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: {
+    overlayWindow?.statusBarViewController.dismiss(withDuration: animated ? 0.4 : 0.0, afterDelay: delay ?? 0.0, completion: { [weak self] in
+      guard let self else { return }
+      if self.styleCache.userStyles.contains(where: { $0.value.systemStatusBarStyle == .defaultStyle }) {
+         self.styleCache.resetDefaultStyle()
+      }
       completion?(self)
     })
   }


### PR DESCRIPTION
Please look at gif below:

![twincircle](https://github.com/calimarkus/JDStatusBarNotification/assets/17738992/aae2a579-d2e0-412a-a7b4-45d2a499634c)

Since StatusBarNotificationStyle is a class type, all defaultStyles in the userStyles dictionary point to the same memory address. 
So the problem that caused the above gif was that the value of minimumWidth was changed when defaultStyle was used for the first time. The value of minimumWidth was still the same when used for the second time.