### PR TITLE
fixed issue 142:swiftUI view is not vertical centered on notch devices

### DIFF
--- a/JDStatusBarNotification/Public/NotificationPresenter.swift
+++ b/JDStatusBarNotification/Public/NotificationPresenter.swift
@@ -181,7 +181,7 @@ public class NotificationPresenter: NSObject, NotificationWindowDelegate {
                                @ViewBuilder viewBuilder: () -> some View,
                                completion: Completion? = nil) -> UIView
   {
-    let controller = UIHostingController(rootView: viewBuilder())
+    let controller = UIHostingController(rootView: viewBuilder().edgesIgnoringSafeArea(.all))
     controller.view.backgroundColor = .clear
     return presentCustomView(controller.view,
                              sizingController: HostingControllerSizingController(for: controller),


### PR DESCRIPTION
SwiftUI viewBuilder add ignore safe area, and SwiftUI view will centered.

**Test in notch device**
<img width="291" alt="image" src="https://github.com/user-attachments/assets/b97019d5-4926-4373-8684-01849e7411bf">

Test in iPhone SE 3rd(non-notch device)
<img width="294" alt="image" src="https://github.com/user-attachments/assets/b6be9736-4834-4601-b5c0-80fe0d6479e4">


